### PR TITLE
All zero check

### DIFF
--- a/hotspot/hotspot.py
+++ b/hotspot/hotspot.py
@@ -129,7 +129,7 @@ class Hotspot:
         if model not in valid_models:
             raise ValueError("Input `model` should be one of {}".format(valid_models))
 
-        valid_genes = counts.sum(axis=1) > 0
+        valid_genes = counts.sum(axis=1) != 0
         n_invalid = counts.shape[0] - valid_genes.sum()
         if n_invalid > 0:
             raise ValueError(

--- a/hotspot/hotspot.py
+++ b/hotspot/hotspot.py
@@ -129,7 +129,13 @@ class Hotspot:
         if model not in valid_models:
             raise ValueError("Input `model` should be one of {}".format(valid_models))
 
-        valid_genes = counts.sum(axis=1) != 0
+        # valid_genes = counts.sum(axis=1) > 0
+
+        if issparse(counts):
+            valid_genes = ~np.array(counts.getnnz(axis=1) == 0)
+        else:
+            valid_genes = ~np.all(counts == 0, axis=1)
+
         n_invalid = counts.shape[0] - valid_genes.sum()
         if n_invalid > 0:
             raise ValueError(


### PR DESCRIPTION
In the Hotspot init, there is a check to ensure that a gene is not 'all zero'. i..e. never expressed in any cell. 

It checks that the sum of its expression over all cells is greater than 0, which makes sense if we consider NB or Bernoulli data; but if we have 'normal' or 'none' (meaning no assumption about data distribution but assuming data is already standardized) one can get negative or zero sums.  For instance this is the case if one wants to compute the autocorrelation of module scores, which are PC loadings and real numbers. 

Thus I propose to change the valid_genes computation to consider an 'all zero' column iff all elements are zero. 